### PR TITLE
close #32 動作確認用の競技システムの構築とそれに伴う修正

### DIFF
--- a/scripts/kill_official_server.sh
+++ b/scripts/kill_official_server.sh
@@ -5,5 +5,5 @@
 #   - テスト用の競技システムが起動している
 #   - テスト用の競技システムとLANケーブルで接続している
 
-KILL_COMMAND='ps aux | grep node | grep -v "grep" | awk '\''{print $2}'\'' | sudo xargs -r kill -9'
-ssh et2023@official-system "$KILL_COMMAND"
+KILL_SERVER_COMMAND='ps aux | grep node | grep -v "grep" | awk '\''{print $2}'\'' | sudo xargs -r kill -9'
+ssh et2023@official-system "$KILL_SERVER_COMMAND"

--- a/scripts/kill_official_server.sh
+++ b/scripts/kill_official_server.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# テスト用の競技システムのWebサーバをkillする
+#  使用条件
+#   - テスト用の競技システムが起動している
+#   - テスト用の競技システムとLANケーブルで接続している
+
+KILL_COMMAND='ps aux | grep node | grep -v "grep" | awk '\''{print $2}'\'' | sudo xargs -r kill -9'
+ssh et2023@official-system "$KILL_COMMAND"

--- a/scripts/run_official_server.sh
+++ b/scripts/run_official_server.sh
@@ -5,5 +5,5 @@
 #   - テスト用の競技システムが起動している
 #   - テスト用の競技システムとLANケーブルで接続している
 
-SERVE_COMMAND="cd /opt/compesys && sudo npm run start"
-ssh et2023@official-system "${SERVE_COMMAND}" 
+RUN_SERVER_COMMAND="cd /opt/compesys && sudo npm run start"
+ssh et2023@official-system "${RUN_SERVER_COMMAND}"

--- a/scripts/run_official_server.sh
+++ b/scripts/run_official_server.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# テスト用の競技システムのWebサーバを起動する
+#  使用条件
+#   - テスト用の競技システムが起動している
+#   - テスト用の競技システムとLANケーブルで接続している
+
+SERVE_COMMAND="cd /opt/compesys && sudo npm run start"
+ssh et2023@official-system "${SERVE_COMMAND}" 

--- a/src/official_interface.py
+++ b/src/official_interface.py
@@ -93,7 +93,7 @@ class OfficialInterface:
         return success
 
 if __name__ == "__main__":
-    ("test-start")
+    print("test-start")
     OfficialInterface.set_train_pwm(10)
-    OfficialInterface.upload_snap("../fig_image/fig1.png")
-    ("test-end")
+    OfficialInterface.upload_snap("../tests/testdata/img/fig.png")
+    print("test-end")

--- a/src/official_interface.py
+++ b/src/official_interface.py
@@ -84,10 +84,16 @@ class OfficialInterface:
             response = requests.post(url, headers=headers,
                                      data=image_data, params=params)
             # レスポンスのステータスコードが200の場合、通信成功
-            if response.status_code != 200:
+            if response.status_code != 201:
                 raise ResponseError("Failed to send fig image.")
             success = True
         except Exception as e:
             print(e)
             success = False
         return success
+
+if __name__ == "__main__":
+    ("test-start")
+    OfficialInterface.set_train_pwm(10)
+    OfficialInterface.upload_snap("../fig_image/fig1.png")
+    ("test-end")

--- a/src/official_interface.py
+++ b/src/official_interface.py
@@ -83,7 +83,7 @@ class OfficialInterface:
             # APIにリクエストを送信
             response = requests.post(url, headers=headers,
                                      data=image_data, params=params)
-            # レスポンスのステータスコードが200の場合、通信成功
+            # レスポンスのステータスコードが201の場合、通信成功
             if response.status_code != 201:
                 raise ResponseError("Failed to send fig image.")
             success = True

--- a/tests/test_official_interface.py
+++ b/tests/test_official_interface.py
@@ -29,7 +29,7 @@ class TestOfficialInterface:
     @mock.patch("requests.post")
     def test_upload_snap(self, mock_post):
         mock_response = mock.Mock(spec=Response)
-        mock_response.status_code = 200
+        mock_response.status_code = 201
         mock_post.return_value = mock_response
         img_path = "tests/testdata/img/fig.png"
         OfficialInterface.upload_snap(img_path)


### PR DESCRIPTION
## チェックリスト
- [x] format(autopep8) している
- [x] コーディング規約(pep8)に準じている
- [x] チケットの完了条件を満たしている

## 変更点
- フィグ画像の送信成功のステータスコードの修正(200だと思ってたら201でした)
- 動作確認用競技システムの起動・停止を行うスクリプトを追加

以下、今後の動作確認のために競技システムをいじりました。
- 実際のIoT列車にPWM値を指定する関数setPWM()の呼び出しをコメント化(Server Errorになるため)
- 各APIのレスポンスに以下の情報を追加(カメラシステムはステータスコードしか参照しないため影響はないはず)
  - IoT列車のPWM値指定API:  pwm: setPWM()の引数に入る値
  - フィグ画像の送信API: path: 送信したフィグ画像が保存されたパス

## 競技システムの使い方
1. LANケーブルで、競技システムとカメラシステム用のPCを接続する
2. 競技システムに電源(Type-C)を指す
3. 少し待つ(公式では数分って書いてたけど数十秒でいいと思います)
4. カメラシステムで、`$ bash scripts/run_official_server.sh`を実行する(特に問題なければ作業中は起動しっぱなしでOK)
5. 作業が終わったら、Ctrl+Cでサーバを停止する
6. `$ ssh et2023@official-system sudo shutdown now`でシャットダウンする

もし、うまく起動できない場合や、Ctrl+Zしてしまった場合は、 `$ bash scripts/kill_official_server.sh`を実行すると、サーバのプロセスがキルできます。

研究室PCとおいておくので、カメラシステムを動作させる場合は使ってみてください。
![image](https://github.com/KatLab-MiyazakiUniv/etrobocon2023-camera-system/assets/83441177/64e21e3c-1f0a-455b-86d8-86b23c20212e)

## 動作テスト
研究室PCのカメラシステムと競技システムをLANケーブルで接続し、OfficialInterfaceを実行し、以下を確認した。
- IoT列車のPWM値指定については、競技システムが正しく値を受け取っていること
フィグ画像の送信では、競技システムが指定しいるパスに送信した画像が保存されていること
- それぞれ成功のステータスコードを返すこと
