### PR TITLE
close #38 キャリブレーション時にカメラIDを指定する

### DIFF
--- a/src/camera_system.py
+++ b/src/camera_system.py
@@ -60,7 +60,6 @@ class CameraSystem:
         # sever_ipは、Bluetooth接続なら172.20.1.1
         # Wi-Fi接続なら、走行体１は192.168.11.16、走行体２は192.168.11.17
         client = Client(self.raspike_ip)
-        pre_state = ""
 
         # Webカメラのキャリブレーション
         tt = TrainTracker()
@@ -69,20 +68,18 @@ class CameraSystem:
         while True:
             state = client.get_robot_state()
             # 走行体の状態が"finish"になった時、終了する。
-            if state == "finish":
-                print(state)
-                break
-            elif state == "lap" and state != pre_state:
+            if state == "lap":
                 # IoT列車の監視を開始
                 tt.observe()
 
                 # ロボコンスナップ攻略開始
                 snap = RoboSnap(self.raspike_ip)
                 snap.start_snap()
+
+                # 処理を終了
+                break
             else:
                 print(state)
 
-            # 状態の保持
-            pre_state = state
             # 2秒待つ
             time.sleep(2)

--- a/src/camera_system.py
+++ b/src/camera_system.py
@@ -66,8 +66,8 @@ class CameraSystem:
         tt.calibrate()
 
         while True:
+            # 走行状況を取得
             state = client.get_robot_state()
-            # 走行体の状態が"finish"になった時、終了する。
             if state == "lap":
                 # IoT列車の監視を開始
                 tt.observe()
@@ -76,7 +76,7 @@ class CameraSystem:
                 snap = RoboSnap(self.raspike_ip)
                 snap.start_snap()
 
-                # 処理を終了
+                # カメラシステムを終了
                 break
             else:
                 print(state)

--- a/src/camera_system.py
+++ b/src/camera_system.py
@@ -63,7 +63,7 @@ class CameraSystem:
         pre_state = ""
 
         # Webカメラのキャリブレーション
-        tt = TrainTracker(0)
+        tt = TrainTracker()
         tt.calibrate()
 
         while True:
@@ -74,7 +74,6 @@ class CameraSystem:
                 break
             elif state == "lap" and state != pre_state:
                 # IoT列車の監視を開始
-                # TODO:observeが"q"を押さないと終了しないバグを修正
                 tt.observe()
 
                 # ロボコンスナップ攻略開始

--- a/src/train_tracker.py
+++ b/src/train_tracker.py
@@ -117,7 +117,7 @@ class TrainTracker:
     def observe(self) -> None:
         """映像を監視する."""
         WINDOW_NAME = "Observe"
-        # キャリブレーション用のウィンドウを生成
+        # IoT列車攻略の確認用のウィンドウを生成
         cv2.namedWindow(WINDOW_NAME)
 
         # 録画を開始する

--- a/src/train_tracker.py
+++ b/src/train_tracker.py
@@ -31,7 +31,8 @@ class TrainTracker:
             cv2.setMouseCallback(WINDOW_NAME, self.mouse_callback)
 
             # 入力された数字をカメラIDとして扱う
-            print("Press key for the camera ID with focus on the Calibration window.")
+            print("Press key for the camera ID \
+                  with focus on the Calibration window.")
             key = cv2.waitKey(0)
             # 数字が入力されるまで入力を要求する
             while not chr(key).isdecimal():
@@ -42,7 +43,8 @@ class TrainTracker:
                 camera = CameraInterface(camera_id)
                 success, _ = camera.get_frame()
                 if not success:
-                    raise Exception(f"Error: Unable to access a camera with camera ID {camera_id}.")
+                    raise Exception(f"Error: Unable to access \
+                                    a camera with camera ID {camera_id}.")
             # CameraInterfaceのインスタンス化に失敗した場合、再度カメラIDの入力にもどる
             except Exception as error:
                 print(error)
@@ -51,7 +53,8 @@ class TrainTracker:
             # 録画を開始する
             video, mark_video = camera.start_record()
             # クリックされた領域を監視対象とする。"q"キーで決定, "r"キーでカメラID再入力
-            print("Click the upper left and lower right of the area to observe and press the 'q' key.")
+            print("Click the upper left and lower right of the area \
+                  to observe and press the 'q' key.")
             print("If switching camera, press the 'r' key.")
             while True:
                 # フレームを取得
@@ -132,13 +135,15 @@ class TrainTracker:
                 break
 
             # 列車の検出
-            mark_frame, train_rect_points = self.detect_train(frame, initial_frame)
+            mark_frame, train_rect_points = self.detect_train(
+                frame, initial_frame)
             # クリックされた領域の描画
             mark_frame = self.draw_observe_rect(mark_frame)
 
             if len(train_rect_points) >= 2:
-                # 列車の境界 (左,上(使用しない)),(右,下) 
-                (train_left, _), (train_right, train_bottom) = train_rect_points
+                # 列車の境界 (左,上(使用しない)),(右,下)
+                (train_left, _), (train_right,
+                                  train_bottom) = train_rect_points
                 # 描画した指定領域
                 observe_y_values = [y for _, y in self.observe_rect_points]
                 observe_x_values = [x for x, _ in self.observe_rect_points]

--- a/src/train_tracker.py
+++ b/src/train_tracker.py
@@ -117,7 +117,7 @@ class TrainTracker:
     def observe(self) -> None:
         """映像を監視する."""
         WINDOW_NAME = "Observe"
-        # IoT列車攻略の確認用のウィンドウを生成
+        # IoT列車攻略中に表示するウィンドウを生成
         cv2.namedWindow(WINDOW_NAME)
 
         # 録画を開始する

--- a/tests/test_camera_system.py
+++ b/tests/test_camera_system.py
@@ -25,7 +25,7 @@ class TestCameraSystem:
 
         # モック化したクラスや関数などの返り値を設定
         mock_upload_snap.return_value = None
-        mock_get_robot_state.return_value = "finish"
+        mock_get_robot_state.return_value = "lap"
         mock_calibrate.return_value = None
         mock_observe.return_value = None
         mock_mkdir_fig_img.return_value = None

--- a/tests/test_train_tracker.py
+++ b/tests/test_train_tracker.py
@@ -2,37 +2,38 @@
 
 @author: miyashita64
 """
-from src.train_tracker import TrainTracker
 from unittest import mock
+from src.train_tracker import TrainTracker
+from src.camera_interface import CameraInterface
 
 
+@mock.patch("cv2.VideoWriter", mock.Mock())
+@mock.patch("cv2.namedWindow", mock.Mock())
+@mock.patch("cv2.imshow", mock.Mock())
+@mock.patch("cv2.cvtColor", mock.Mock())
+@mock.patch("cv2.rectangle", mock.Mock())
+@mock.patch("cv2.setMouseCallback", mock.Mock())
+@mock.patch("src.train_tracker.CameraInterface.get_frame",
+            return_value=(True, mock.Mock()))
+@mock.patch("src.train_tracker.CameraInterface.start_record",
+            return_value=(mock.Mock(), mock.Mock()))
+@mock.patch("src.train_tracker.CameraInterface.end_record", mock.Mock())
 class TestTrainTracker:
-    @mock.patch('cv2.VideoWriter')
-    @mock.patch("cv2.namedWindow")
-    @mock.patch("cv2.setMouseCallback")
-    @mock.patch("cv2.waitKey", side_effect=[ord("q"), ord("q"), ord("q")])
-    @mock.patch("src.train_tracker.CameraInterface.end_record")
-    def test_calibrate(self, mock_end_record, mock_wait_key,
-                       mock_set_mouse_callback,
-                       mock_named_window, mock_video_writer):
-        mock_end_record.return_value = None
-        mock_set_mouse_callback.return_value = None
-        mock_named_window.return_value = None
-        mock_video_writer.return_value = mock.Mock()    # 動画ファイルを生成しない
-        tt = TrainTracker(2)
+    @mock.patch("cv2.waitKey",
+                side_effect=[ord("0"), ord("0"), ord("0"),
+                             ord("q"), ord("q"), ord("q")])
+    def test_calibrate(self, mock_get_frame, *mocks):
+        tt = TrainTracker()
         tt.calibrate()
 
-    @mock.patch('cv2.VideoWriter')
-    @mock.patch("cv2.namedWindow")
-    @mock.patch("cv2.setMouseCallback")
-    @mock.patch("cv2.waitKey", side_effect=[ord("q"), ord("q"), ord("q")])
-    @mock.patch("src.train_tracker.CameraInterface.end_record")
-    def test_observe(self, mock_end_record, mock_wait_key,
-                     mock_set_mouse_callback,
-                     mock_named_window, mock_video_writer):
-        mock_end_record.return_value = None
-        mock_set_mouse_callback.return_value = None
-        mock_named_window.return_value = None
-        mock_video_writer.return_value = mock.Mock()    # 動画ファイルを生成しない
-        tt = TrainTracker(2)
+    @mock.patch("cv2.waitKey", side_effect=[ord("0"), ord("0"), ord("0"),
+                                            ord("q"), ord("q"), ord("q")])
+    @mock.patch("src.train_tracker.TrainTracker.detect_train",
+                return_value=(mock.Mock(), [(20, 1), (80, 50)]))
+    @mock.patch("src.train_tracker.OfficialInterface.set_train_pwm",
+                mock.Mock())
+    def test_observe(self, mock_detect_train, *mocks):
+        tt = TrainTracker()
+        tt.calibrate()
+        tt.observe_rect_points = [(10, 40), (90, 60)]
         tt.observe()


### PR DESCRIPTION
## チェックリスト

- [x] format(autopep8) している
- [x] コーディング規約(pep8)に準じている
- [x] チケットの完了条件を満たしている

## 変更点
- キャリブレーション中のIoT列車の監視範囲指定の際にカメラIDを指定する処理を追加
  1. 数字キーを入力でカメラIDを指定
  2. クリックで監視範囲を指定。カメラを切り替える場合は"r"キーを押し1.へ戻る
  3. "q"キーで確定
- 監視時にカメラの映像を確認できないバグを修正(スリープを追加)

## 動作テスト
- キャリブレーションでカメラIDを設定できることを確認した(動画参照)。
- 指定範囲内を動体が通過した際に、競技システムへリクエストを送ろうとすることを確認した。

キャリブレーションの様子(printについては少し変えてます)

https://github.com/KatLab-MiyazakiUniv/etrobocon2023-camera-system/assets/83441177/188c9619-c242-48c4-8e6d-87258a172f21

