### PR TITLE
close #42 コースアウト時に画像を送信できるように変更

### DIFF
--- a/src/robo_snap.py
+++ b/src/robo_snap.py
@@ -181,7 +181,6 @@ class RoboSnap:
             timeout_flag = False  # タイムアウトしたかどうかを判定するフラグ
             i = 0
             while True:
-                start_time = 0.0  # 次の画像の受信開始前のタイムスタンプ
                 i += 1
                 # 走行体から画像を取得
                 while True:  # 画像が見つかるまでループ

--- a/src/robo_snap.py
+++ b/src/robo_snap.py
@@ -211,25 +211,26 @@ class RoboSnap:
                     # 配置エリアBの画像は検出せずにアップロード
                     if OfficialInterface.upload_snap(self.fig_B_img_path):
                         self.successful_send_fig_B = True
-                        if self.successful_send_best_shot or self.successful_send_candidate:
+                        if self.successful_send_best_shot or \
+                                self.successful_send_candidate:
                             break
                     continue
 
                 # コースアウト判定でFigAを送信したのに、新たなFigAを取得してしまった場合
-                elif self.successful_send_best_shot or self.successful_send_candidate:
+                elif self.successful_send_best_shot or \
+                        self.successful_send_candidate:
                     continue
 
                 # コースアウトしているならば、候補写真を送信し、次の画像を探し続ける
                 if timeout_flag:
                     if self.candidate_img_path is not None:
-                        if OfficialInterface.upload_snap(self.candidate_img_path):
+                        if OfficialInterface.upload_snap(
+                                self.candidate_img_path):
                             self.successful_send_candidate = True
                             if self.successful_send_fig_B:
                                 break
                     timeout_flag = False
                     continue
-
-                
 
                 # 物体検出
                 detected_img_path = os.path.join(

--- a/tests/test_robo_snap.py
+++ b/tests/test_robo_snap.py
@@ -49,9 +49,8 @@ class TestRoboSnap:
                         mock_detect_object):
         """ロボコンスナップ攻略クラスのテスト."""
         mock_detect_object.return_value = []
-        mock_upload_snap.return_value = False
+        mock_upload_snap.return_value = True
         assert self.snap.start_snap() is None
-
         # 画像が生成されているかのチェック
         for img in self.snap.img_list:
             check_img_path = os.path.join(


### PR DESCRIPTION
## チェックリスト

- [x] format(autopep8) している
- [x] コーディング規約(pep8)に準じている
- [x] チケットの完了条件を満たしている

## 変更点

- ロボコンスナップにおいて、一定時間内に次の画像を受信できなければコースアウトしたとみなし、現時点でのベスト画像を送信する処理に移行する処理を追加
  - robo_snap.pyのstart_snap()内の画像を走行体から受信する部分の変更
  - ロボコンスナップの各区間におけるタイムアウト時間を保持するクラスの作成(列挙型enum)

## 動作テスト
実際に実機でコースアウトした時に画像が送信されるかの確認はまだしていない